### PR TITLE
Resolve client rect errors

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,0 +1,59 @@
+import { isDOMRect } from '../src/utils'
+
+test('isDOMRect returns false when no element is passed', () => {
+  expect(isDOMRect()).toBe(false);
+})
+
+test('isDOMRect returns false for null input', () => {
+  expect(isDOMRect(null)).toBe(false);
+})
+
+test('isDOMRect returns false for primitive types', () => {
+  expect(isDOMRect(1)).toBe(false);
+})
+
+test('isDOMRect returns false for empty strings', () => {
+  expect(isDOMRect('')).toBe(false);
+})
+
+test('isDOMRect returns false for non-empty strings', () => {
+  expect(isDOMRect('1')).toBe(false);
+})
+
+test('isDOMRect returns false for empty', () => {
+  expect(isDOMRect({})).toBe(false);
+})
+
+test('isDOMRect returns false for arrays', () => {
+  expect(isDOMRect([])).toBe(false);
+})
+
+test('isDOMRect returns false when "top" is missing from the rect object', () => {
+  const rect = { left: 0, right: 0, bottom: 0}
+  expect(isDOMRect(rect)).toBe(false);
+})
+
+test('isDOMRect returns false when "left" is missing from the rect object', () => {
+  const rect = { top: 0, right: 0, bottom: 0}
+  expect(isDOMRect(rect)).toBe(false);
+})
+
+test('isDOMRect returns false when "right" is missing from the rect object', () => {
+  const rect = { top: 0, left: 0, bottom: 0}
+  expect(isDOMRect(rect)).toBe(false);
+})
+
+test('isDOMRect returns false when "bottom" is missing from the rect object', () => {
+  const rect = { top: 0, left: 0, right: 0}
+  expect(isDOMRect(rect)).toBe(false);
+})
+
+test('isDOMRect returns true for objects that mimic DOMRect', () => {
+  const rect = { top: 0, left: 0, right: 0, bottom: 0}
+  expect(isDOMRect(rect)).toBe(true);
+})
+
+test('isDOMRect returns true for true DOMRect objects', () => {
+  const el = document.createElement('div');
+  expect(isDOMRect(el.getBoundingClientRect())).toBe(true);
+})

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -20,7 +20,7 @@ test('isDOMRect returns false for non-empty strings', () => {
   expect(isDOMRect('1')).toBe(false);
 })
 
-test('isDOMRect returns false for empty', () => {
+test('isDOMRect returns false for empty objects', () => {
   expect(isDOMRect({})).toBe(false);
 })
 
@@ -29,27 +29,27 @@ test('isDOMRect returns false for arrays', () => {
 })
 
 test('isDOMRect returns false when "top" is missing from the rect object', () => {
-  const rect = { left: 0, right: 0, bottom: 0}
+  const rect = { left: 0, right: 0, bottom: 0 }
   expect(isDOMRect(rect)).toBe(false);
 })
 
 test('isDOMRect returns false when "left" is missing from the rect object', () => {
-  const rect = { top: 0, right: 0, bottom: 0}
+  const rect = { top: 0, right: 0, bottom: 0 }
   expect(isDOMRect(rect)).toBe(false);
 })
 
 test('isDOMRect returns false when "right" is missing from the rect object', () => {
-  const rect = { top: 0, left: 0, bottom: 0}
+  const rect = { top: 0, left: 0, bottom: 0 }
   expect(isDOMRect(rect)).toBe(false);
 })
 
 test('isDOMRect returns false when "bottom" is missing from the rect object', () => {
-  const rect = { top: 0, left: 0, right: 0}
+  const rect = { top: 0, left: 0, right: 0 }
   expect(isDOMRect(rect)).toBe(false);
 })
 
 test('isDOMRect returns true for objects that mimic DOMRect', () => {
-  const rect = { top: 0, left: 0, right: 0, bottom: 0}
+  const rect = { top: 0, left: 0, right: 0, bottom: 0 }
   expect(isDOMRect(rect)).toBe(true);
 })
 

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from "react"
 import ReactDOM from "react-dom"
+import { isDOMRect } from './utils'
 
 type Props = {
     element : HTMLElement,
@@ -127,7 +128,7 @@ export default class Popover extends Component {
         const half_window_width  = window.innerWidth / 2
         const element_rect       = this.state.element_rect
 
-        if (element_rect instanceof ClientRect) {
+        if (isDOMRect(element_rect)) {
             const horizontal = element_rect.left > half_window_width ? 'TooltipRight' : 'TooltipLeft'
             const vertical   = element_rect.top > half_window_height ? 'TooltipAbove' : 'TooltipBelow'
 
@@ -148,7 +149,7 @@ export default class Popover extends Component {
         const element_rect   = this.state.element_rect
         const container_rect = this.state.parent_rect
 
-        if (element_rect instanceof ClientRect && container_rect instanceof ClientRect) {
+        if (isDOMRect(element_rect) && isDOMRect(container_rect)) {
             const left   = element_rect.left - container_rect.left + parent.scrollLeft
             const top    = element_rect.top - container_rect.top + parent.scrollTop
             const right  = element_rect.right - container_rect.right
@@ -179,7 +180,7 @@ export default class Popover extends Component {
         const tooltip      = this.state.tooltip
         const element_rect = this.state.element_rect
 
-        if (tooltip instanceof HTMLElement && element_rect instanceof ClientRect) {
+        if (tooltip instanceof HTMLElement && isDOMRect(element_rect)) {
             return {
                 top : viewport.top - (tooltip.offsetHeight / 2) + (element_rect.height / 2),
                 left: viewport.left - (tooltip.offsetWidth / 2) + (element_rect.width / 2)
@@ -200,7 +201,7 @@ export default class Popover extends Component {
         const half_window_width  = window.innerWidth / 2
         const element_rect       = this.state.element_rect
 
-        if (element_rect instanceof ClientRect) {
+        if (isDOMRect(element_rect)) {
             const horizontal = element_rect.left > half_window_width ? this.left : this.right
             const vertical   = element_rect.top > half_window_height ? this.above : this.below
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,18 @@
+const isObject = obj => obj != null && typeof obj === 'object';
+
+const isValidBoundingClientRect = clientRect => {
+  if (!isObject(clientRect)) {
+    return false;
+  }
+
+  const { top, left, right, bottom } = clientRect;
+  return top != null && left != null && right != null && bottom != null;
+}
+
+export const isDOMRect = rect => {
+  if (!window.DOMRect) {
+    return isValidBoundingClientRect(rect)
+  }
+
+  return rect instanceof window.DOMRect
+}


### PR DESCRIPTION
Resolves https://github.com/RobertMenke/react-popover/issues/2

[getBoundingClientRect](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect) returns a [DOMRect](https://developer.mozilla.org/en-US/docs/Web/API/DOMRect), not a `ClientRect`.

This change creates a new utility called `isDOMRect` that uses a comparison to `DOMRect` if available (there's limited support across browsers and it isn't supported at all for IE or Edge) If `DOMRect` is not available, `isDOMRect` tries to determine if the properties we need from `getBoundingClientRect` are available to the `rect` object passed to it.

NOTE: After merging you would need to run through your deploy process to update `dist`.

I've deployed a test environment to show that the changes are resolved across browsers: https://brenthosie.github.io/react-popover-deploy-example/